### PR TITLE
Some more macros

### DIFF
--- a/Common-macro-definitions/common-macro-definitions.asd
+++ b/Common-macro-definitions/common-macro-definitions.asd
@@ -40,6 +40,7 @@
    (:file "deftype")
    (:file "destructuring-bind")
    (:file "declaim")
+   (:file "do-symbols")
    (:file "lambda")
    (:file "prog")
    (:file "progstar")

--- a/Common-macro-definitions/common-macro-definitions.asd
+++ b/Common-macro-definitions/common-macro-definitions.asd
@@ -36,6 +36,7 @@
    (:file "defclass")
    (:file "define-condition")
    (:file "defgeneric")
+   (:file "defsetf")
    (:file "deftype")
    (:file "destructuring-bind")
    (:file "declaim")

--- a/Common-macro-definitions/common-macro-definitions.asd
+++ b/Common-macro-definitions/common-macro-definitions.asd
@@ -46,6 +46,7 @@
    (:file "prog2")
    (:file "pushnew")
    (:file "remf")
+   (:file "handler-case")
    (:file "ignore-errors")
    (:file "in-package")
    (:file "check-type")

--- a/Common-macro-definitions/conditions.lisp
+++ b/Common-macro-definitions/conditions.lisp
@@ -43,6 +43,21 @@
 (define-condition malformed-typecase-clause (program-error)
   ((%clause :initarg :clause :reader clause)))
 
+(define-condition variable-name-must-be-symbol (program-error)
+  ((%name :initarg :name :reader name))
+  (:report (lambda (condition stream)
+             (format stream "Expected a variable name,~@
+                             but the following was given instead:~@
+                             ~s"
+                     (name condition)))))
+
+(defun check-variable-name (variable-name)
+  (unless (symbolp variable-name)
+    (error 'variable-name-must-be-symbol :name variable-name)))
+
+(define-condition malformed-handler-case-clause (program-error)
+  ((%clause :initarg :clause :reader clause)))
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;
 ;;; Conditions used at runtime

--- a/Common-macro-definitions/define-compiler-macro.lisp
+++ b/Common-macro-definitions/define-compiler-macro.lisp
@@ -1,6 +1,6 @@
 (cl:in-package #:common-macro-definitions)
 
 (defmacro define-compiler-macro (name lambda-list &body body)
-  (let ((expansion (ecc:parse-macro name lambda-list body)))
+  (let ((expansion (ecc:parse-compiler-macro name lambda-list body)))
     `(eval-when (:compile-toplevel :load-toplevel :execute)
        (setf (compiler-macro-function ',name) ,expansion))))

--- a/Common-macro-definitions/defmacro.lisp
+++ b/Common-macro-definitions/defmacro.lisp
@@ -3,4 +3,4 @@
 (defmacro defmacro (name lambda-list &body body)
   (let ((expansion (ecc:parse-macro name lambda-list body)))
     `(eval-when (:compile-toplevel :load-toplevel :execute)
-       (setf (macro-function ',name) ,expansion))))
+       (setf (cl:macro-function ',name) ,expansion))))

--- a/Common-macro-definitions/defsetf.lisp
+++ b/Common-macro-definitions/defsetf.lisp
@@ -39,5 +39,5 @@
        (expand-short-defsetf access-fn update-fn documentation)))
     (list ; long form
      (destructuring-bind (lambda-list (&rest stores) &body body) rest
-       (assert (every #'symbolp stores))
+       (mapc #'check-variable-name stores)
        (expand-long-defsetf access-fn lambda-list stores body)))))

--- a/Common-macro-definitions/defsetf.lisp
+++ b/Common-macro-definitions/defsetf.lisp
@@ -1,0 +1,43 @@
+(cl:in-package #:common-macro-definitions)
+
+(defun expand-short-defsetf (access-fn update-fn documentation)
+  `(define-setf-expander ,access-fn (&rest args)
+     ,documentation ; if NIL, harmless.
+     (let ((temps (loop for arg in args collect (gensym)))
+           (store (gensym "STORE")))
+       (values temps args (list store)
+               `(,',update-fn ,@temps ,store)
+               `(,',access-fn ,@temps)))))
+
+;;; Note that the long form of DEFSETF is poorly defined for some obscure cases.
+;;; See e.g. https://bugs.launchpad.net/sbcl/+bug/1452947
+(defun expand-long-defsetf (access-fn lambda-list stores body)
+  (let* ((argforms (gensym "ARGFORMS"))
+         (temps (gensym "TEMPS"))
+         (ll (ecclesia:parse-defsetf-lambda-list lambda-list))
+         (eparam1 (ecclesia:environment ll))
+         (eparam (if (eq eparam1 :none) nil eparam1)))
+    (multiple-value-bind (bindings ignores) (ecc:destructure-lambda-list ll argforms)
+      `(define-setf-expander ,access-fn (&rest ,argforms
+                                           ,@(when eparam `(&environment ,eparam)))
+         (let ((,temps (loop repeat (length ,argforms) collect (gensym))))
+           (values ,temps ,argforms ',stores
+                   (let* (,@bindings
+                          ;; we rebind eparam so that body declarations can apply to it.
+                          ,@(when eparam `((,eparam ,eparam))))
+                     (declare (ignore ,@ignores))
+                     ,@body)
+                   ;; avoiding some weird double unquotes
+                   (list* ',access-fn ,argforms)))))))
+
+(defmacro defsetf (access-fn &rest rest)
+  (check-type access-fn symbol)
+  (etypecase (first rest)
+    (symbol ; short form
+     (destructuring-bind (update-fn &optional (documentation nil docp)) rest
+       (when docp (check-type documentation string))
+       (expand-short-defsetf access-fn update-fn documentation)))
+    (list ; long form
+     (destructuring-bind (lambda-list (&rest stores) &body body) rest
+       (assert (every #'symbolp stores))
+       (expand-long-defsetf access-fn lambda-list stores body)))))

--- a/Common-macro-definitions/do-symbols.lisp
+++ b/Common-macro-definitions/do-symbols.lisp
@@ -1,0 +1,30 @@
+(cl:in-package #:common-macro-definitions)
+
+;;; Based on SBCL's.
+
+(defun expand-do-*-symbols (package-list-form range variable body result)
+  ;; package-list-form can be a single package, as per definition of
+  ;; with-package-iterator that it takes a list designator.
+  (multiple-value-bind (declarations forms) (ecc:separate-ordinary-body body)
+    (let ((iterator (gensym "PACKAGE-ITERATOR"))
+          (rp (gensym)) (loop (gensym "LOOP")))
+      `(block nil
+         (with-package-iterator (,iterator ,package-list-form ,@range)
+           (tagbody
+              ,loop
+              (multiple-value-bind (,rp ,variable) (,iterator)
+                ,@declarations
+                (if ,rp
+                    (tagbody ,@forms (go ,loop))
+                    (return ,result)))))))))
+
+(defmacro do-symbols ((var &optional (package '*package*) result) &body body)
+  (expand-do-*-symbols package '(:internal :external :inherited)
+                       var body result))
+
+(defmacro do-external-symbols ((var &optional (package '*package*) result) &body body)
+  (expand-do-*-symbols package '(:external) var body result))
+
+(defmacro do-all-symbols ((var &optional result) &body body)
+  ;; don't need :inherited since we're already covering all packages.
+  (expand-do-*-symbols '(list-all-packages) '(:internal :external) var body result))

--- a/Common-macro-definitions/handler-case.lisp
+++ b/Common-macro-definitions/handler-case.lisp
@@ -1,0 +1,59 @@
+(cl:in-package #:common-macro-definitions)
+
+(defmacro handler-case (form &rest clauses)
+  (let ((no-error-clause (assoc :no-error clauses)))
+    (if no-error-clause
+        ;; if we have a no-error clause, we handle it specially,
+        ;; and use an inner handler-case with no no-error clause.
+        (let ((normal-return (gensym "NORMAL-RETURN"))
+              (error-return (gensym "ERROR-RETURN")))
+          ;; If there's no error, it goes to the m-v-call.
+          ;; If there is, and the handler-case returns, it aborts
+          ;; back to error-return.
+          `(block ,error-return
+             (multiple-value-call (lambda ,@(rest no-error-clause))
+               (block ,normal-return
+                 (return-from ,error-return
+                   (handler-case (return-from ,normal-return ,form)
+                     ,@(remove no-error-clause clauses)))))))
+        ;; Now in the usual no no-error case, what we do is expand
+        ;; to a tagbody. All the handlers set a variable to the condition,
+        ;; then GO to a body in the tagbody. This handles HANDLER-CASE's
+        ;; unwinding behavior.
+        ;; We also FLET the handlers with DX because why not?
+        (let ((exit (gensym "HANDLER-CASE-EXIT"))
+              (tags (loop for clause in clauses
+                          collect (gensym "HANDLER-TAG")))
+              (fnames (loop for clause in clauses
+                            collect (gensym "HANDLER")))
+              (condition (gensym "CONDITION"))
+              ;; This is just to avoid our package name leaking in.
+              (temp '#:temp))
+          `(block ,exit
+             (let ((,condition nil))
+               (declare (ignorable ,condition))
+               (tagbody
+                  (flet (,@(loop for fname in fnames
+                                 for tag in tags
+                                 collect `(,fname (,temp)
+                                            (setq ,condition ,temp)
+                                            (go ,tag))))
+                    (declare (dynamic-extent
+                              ,@(loop for fname in fnames
+                                      collect `(function ,fname))))
+                    (return-from ,exit
+                      (handler-bind
+                          (,@(loop for (type) in clauses
+                                   for fname in fnames
+                                   collect `(,type (function ,fname))))
+                        ,form)))
+                  ;; Now the handler bodies.
+                  ,@(loop for tag in tags
+                          for (_ maybe-ll . body) in clauses
+                          collect tag
+                          collect `(return-from ,exit
+                                     ,(etypecase maybe-ll
+                                        ((cons symbol null)
+                                         `(let ((,(first maybe-ll) ,condition))
+                                            ,@body))
+                                        (null `(locally ,@body))))))))))))

--- a/Common-macro-definitions/handler-case.lisp
+++ b/Common-macro-definitions/handler-case.lisp
@@ -1,6 +1,11 @@
 (cl:in-package #:common-macro-definitions)
 
 (defmacro handler-case (form &rest clauses)
+  (loop for clause in clauses
+        unless (and (ecc:proper-list-p clause)
+                 (>= (length clause) 2)
+                 (typep (second clause) '(or symbol (cons symbol null))))
+          do (error 'malformed-handler-case-clause :clause clause))
   (let ((no-error-clause (assoc :no-error clauses)))
     (if no-error-clause
         ;; if we have a no-error clause, we handle it specially,

--- a/Common-macro-definitions/multiple-value-bind.lisp
+++ b/Common-macro-definitions/multiple-value-bind.lisp
@@ -5,12 +5,16 @@
 ;;; Macro MULTIPLE-VALUE-BIND.
 ;;;
 ;;; We define this macro pretty much exactly as the HyperSpec says in
-;;; the "Notes:" section on the page describing MULTIPLE-VALUE-BIND.  
+;;; the "Notes:" section on the page describing MULTIPLE-VALUE-BIND.
+;;; As a slight optimization, if there is only one variable we reduce
+;;; to LET. This is nice for e.g. SETF.
 
 (defmacro multiple-value-bind (variables values-form &body body)
-  (let ((rest-variable (gensym)))
-    `(multiple-value-call
-         (lambda (&optional ,@variables &rest ,rest-variable)
-           (declare (ignore ,rest-variable))
-           ,@body)
-       ,values-form)))
+  (if (= (length variables) 1)
+      `(let ((,(first variables) ,values-form)) ,@body)
+      (let ((rest-variable (gensym)))
+        `(multiple-value-call
+             (lambda (&optional ,@variables &rest ,rest-variable)
+               (declare (ignore ,rest-variable))
+               ,@body)
+           ,values-form))))

--- a/Common-macro-definitions/multiple-value-setq.lisp
+++ b/Common-macro-definitions/multiple-value-setq.lisp
@@ -1,1 +1,9 @@
 (cl:in-package #:common-macro-definitions)
+
+(defmacro multiple-value-setq (vars value-form)
+  (if (null vars)
+      ;; skip SETF if unnecessary.
+      `(values ,value-form)
+      ;; As defined in CLHS.
+      ;; FIXME: Validate that vars are symbols.
+      `(values (setf (values ,@vars) ,value-form))))

--- a/Common-macro-definitions/multiple-value-setq.lisp
+++ b/Common-macro-definitions/multiple-value-setq.lisp
@@ -1,9 +1,9 @@
 (cl:in-package #:common-macro-definitions)
 
 (defmacro multiple-value-setq (vars value-form)
+  (mapc #'check-variable-name vars)
   (if (null vars)
       ;; skip SETF if unnecessary.
       `(values ,value-form)
       ;; As defined in CLHS.
-      ;; FIXME: Validate that vars are symbols.
       `(values (setf (values ,@vars) ,value-form))))

--- a/Common-macro-definitions/packages.lisp
+++ b/Common-macro-definitions/packages.lisp
@@ -3,13 +3,15 @@
 (defpackage #:common-macro-definitions
   (:use #:common-lisp)
   (:local-nicknames (#:ecc #:ecclesia))
-  (:shadow #:macroexpand-1
+  (:shadow #:macro-function
+           #:macroexpand-1
            #:defmacro
            #:get-setf-expansion
            #:ensure-generic-function
            #:proclaim)
   (:export
    #:*client*
+   #:macro-function
    #:macroexpand-1
    #:defmacro
    #:get-setf-expansion

--- a/Common-macro-definitions/remf.lisp
+++ b/Common-macro-definitions/remf.lisp
@@ -1,39 +1,37 @@
 (cl:in-package #:common-macro-definitions)
 
-(defmacro maybe-error (datum predicate expected-type offending-list)
-  `(unless (,predicate ,datum)
-     (error 'must-be-property-list
-            :datum ,datum
-            :expected-type ',expected-type
-            :offending-list ,offending-list)))
-     
-
 (defmacro remf (place indicator &environment environment)
   (multiple-value-bind (vars vals store-vars writer-form reader-form)
       (get-setf-expansion place environment)
     (let ((indicator-value-variable (gensym))
           (store-var (car store-vars)))
-      `(block nil
-         (let ,(mapcar #'list vars vals)
-           (let* ((,store-var ,reader-form)
-                  (,indicator-value-variable ,indicator))
-             (when (null ,store-var)
-               (return nil))
-             (maybe-error ,store-var consp list ,store-var)
-             (maybe-error (cdr ,store-var) consp cons ,store-var)
-             (when (eq ,indicator-value-variable (car ,store-var))
-               (setq ,store-var (cddr ,store-var))
-               ,writer-form
-               (return t))
-             (loop for rest on (cdr ,store-var) by #'cddr
-                   ;; We know that REST is a CONS cell.
-                   do (when (null (cdr rest))
-                        ;; There are no more pairs to test, so we are
-                        ;; done.
-                        (return nil))
-                      (maybe-error (cdr rest) atom list ,store-var)
-                      (maybe-error (cddr rest) atom cons ,store-var)
-                      (when (eq ,indicator-value-variable (cadr rest))
-                        ;; We found a match.
-                        (setf (cdr rest) (cdddr rest))
-                        (return t)))))))))
+      `(macrolet ((maybe-error (datum predicate expected-type offending-list)
+                    `(unless (,predicate ,datum)
+                       (error 'must-be-property-list
+                              :datum ,datum
+                              :expected-type ',expected-type
+                              :offending-list ,offending-list))))
+         (block nil
+           (let ,(mapcar #'list vars vals)
+             (let* ((,store-var ,reader-form)
+                    (,indicator-value-variable ,indicator))
+               (when (null ,store-var)
+                 (return nil))
+               (maybe-error ,store-var consp list ,store-var)
+               (maybe-error (cdr ,store-var) consp cons ,store-var)
+               (when (eq ,indicator-value-variable (car ,store-var))
+                 (setq ,store-var (cddr ,store-var))
+                 ,writer-form
+                 (return t))
+               (loop for rest on (cdr ,store-var) by #'cddr
+                     ;; We know that REST is a CONS cell.
+                     do (when (null (cdr rest))
+                          ;; There are no more pairs to test, so we are
+                          ;; done.
+                          (return nil))
+                        (maybe-error (cdr rest) atom list ,store-var)
+                        (maybe-error (cddr rest) atom cons ,store-var)
+                        (when (eq ,indicator-value-variable (cadr rest))
+                          ;; We found a match.
+                          (setf (cdr rest) (cdddr rest))
+                          (return t))))))))))

--- a/Common-macro-definitions/utilities.lisp
+++ b/Common-macro-definitions/utilities.lisp
@@ -4,8 +4,11 @@
   (intern (string-downcase (symbol-name name))
           (find-package "COMMON-MACRO-DEFINITIONS")))
 
+(defun macro-function (operator)
+  (cl:macro-function (transform-name operator)))
+
 (defun macro-function-exists-p (operator)
-  (not (null (macro-function (transform-name operator)))))
+  (not (null (macro-function operator))))
 
 (cl:defmacro defmacro (name lambda-list &body body)
   `(cl:defmacro ,(transform-name name) ,lambda-list ,@body))

--- a/Common-macro-definitions/with-input-from-string.lisp
+++ b/Common-macro-definitions/with-input-from-string.lisp
@@ -1,1 +1,14 @@
 (cl:in-package #:common-macro-definitions)
+
+(defmacro with-input-from-string ((var string &key index (start 0) end) &body body)
+  (if (null index)
+      ;; simple case
+      `(let ((,var (make-string-input-stream ,string ,start ,end))) ,@body)
+      ;; Have to update INDEX, so more elaborate.
+      (multiple-value-bind (declarations forms) (ecc:separate-ordinary-body body)
+        `(let ((,var (make-string-input-stream ,string ,start ,end)))
+           ,@declarations
+           (unwind-protect
+                (multiple-value-prog1 (progn ,@forms)
+                  (setf ,index (file-position ,var)))
+             (close ,var))))))

--- a/Common-macro-definitions/with-input-from-string.lisp
+++ b/Common-macro-definitions/with-input-from-string.lisp
@@ -1,6 +1,7 @@
 (cl:in-package #:common-macro-definitions)
 
 (defmacro with-input-from-string ((var string &key index (start 0) end) &body body)
+  (check-variable-name var)
   (if (null index)
       ;; simple case
       `(let ((,var (make-string-input-stream ,string ,start ,end))) ,@body)

--- a/Common-macro-definitions/with-open-file.lisp
+++ b/Common-macro-definitions/with-open-file.lisp
@@ -1,1 +1,17 @@
 (cl:in-package #:common-macro-definitions)
+
+(defmacro with-open-file ((stream filespec &rest options
+                           &key (direction :input) (element-type 'character)
+                             if-exists if-does-not-exist external-format)
+                          &body body)
+  ;; keywords are only there to make the lambda list nice.
+  (declare (ignore direction element-type if-exists if-does-not-exist external-format))
+  (multiple-value-bind (declarations forms) (ecc:separate-ordinary-body body)
+    (let ((abortedp (gensym "ABORT")))
+      `(let ((,stream (open ,filespec ,@options)) (,abortedp t))
+         (declare (dynamic-extent ,stream)) ; per CLHS
+         ,@declarations
+         (unwind-protect
+              (multiple-value-prog1 (progn ,@forms) (setq ,abortedp nil))
+           (when ,stream ; can be NIL due to :if-exists nil etc.
+             (close ,stream :abort ,abortedp)))))))

--- a/Common-macro-definitions/with-open-file.lisp
+++ b/Common-macro-definitions/with-open-file.lisp
@@ -6,6 +6,7 @@
                           &body body)
   ;; keywords are only there to make the lambda list nice.
   (declare (ignore direction element-type if-exists if-does-not-exist external-format))
+  (check-variable-name stream)
   (multiple-value-bind (declarations forms) (ecc:separate-ordinary-body body)
     (let ((abortedp (gensym "ABORT")))
       `(let ((,stream (open ,filespec ,@options)) (,abortedp t))

--- a/Common-macro-definitions/with-open-stream.lisp
+++ b/Common-macro-definitions/with-open-stream.lisp
@@ -1,1 +1,9 @@
 (cl:in-package #:common-macro-definitions)
+
+(defmacro with-open-stream ((var stream) &body body)
+  (multiple-value-bind (declarations forms) (ecc:separate-ordinary-body body)
+    `(let ((,var ,stream))
+       (declare (dynamic-extent ,var)) ; per CLHS
+       ,@declarations
+       (unwind-protect (progn ,@forms)
+         (close ,var)))))

--- a/Common-macro-definitions/with-open-stream.lisp
+++ b/Common-macro-definitions/with-open-stream.lisp
@@ -1,6 +1,7 @@
 (cl:in-package #:common-macro-definitions)
 
 (defmacro with-open-stream ((var stream) &body body)
+  (check-variable-name var)
   (multiple-value-bind (declarations forms) (ecc:separate-ordinary-body body)
     `(let ((,var ,stream))
        (declare (dynamic-extent ,var)) ; per CLHS


### PR DESCRIPTION
* `multiple-value-setq`, `with-open-stream`, `with-open-file`, `with-input-from-string` have actual definitions
* `handler-case`, `defsetf`, `do-symbols`, `do-external-symbols`, `do-all-symbols` newly defined
* Defined a `macro-function` helper function to get at the defined macro regardless of how `transform-name` works
* Fixes `define-compiler-macro` to work with funcall forms
* Moves a helper macro in `remf` into a macrolet so that the compilation environment doesn't need to have an internal macro from this system
* Optimizes `(multiple-value-bind (foo) form ...)` into `(let ((foo form)) ...)` which was already done specially for setf

This is all in the plain Lisp Common-macro-definitions, not the Iconoclast stuff.